### PR TITLE
Bump crypto-base version

### DIFF
--- a/smart.json
+++ b/smart.json
@@ -6,6 +6,6 @@
   "version"    : "3.1.2.1",
   "git"        : "https://github.com/Pagebakers/meteor-crypto-sha256.git",
   "packages"   : {
-    "crypto-base": "3.1.2.0"
+    "crypto-base": "3.1.2.1"
   }
 }


### PR DESCRIPTION
The 3.1.2.0 have CryptoJS defined locally.
